### PR TITLE
feat(#2): eject cassandra configuration into CassandraConfig class

### DIFF
--- a/springCass/src/main/java/hello/CassandraConfig.java
+++ b/springCass/src/main/java/hello/CassandraConfig.java
@@ -1,0 +1,35 @@
+package hello;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.cassandra.config.AbstractCassandraConfiguration;
+import org.springframework.data.cassandra.repository.config.EnableCassandraRepositories;
+
+@Configuration
+@EnableCassandraRepositories
+public class CassandraConfig extends AbstractCassandraConfiguration {
+
+    @Value("${spring.data.cassandra.contact-points}")
+    private String contactPoints;
+
+    @Value("${spring.data.cassandra.port}")
+    private int port;
+
+    @Value("${spring.data.cassandra.keyspace-name}")
+    private String keySpace;
+
+    @Override
+    protected String getKeyspaceName() {
+        return keySpace;
+    }
+
+    @Override
+    protected String getContactPoints() {
+        return contactPoints;
+    }
+
+    @Override
+    protected int getPort() {
+        return port;
+    }
+}


### PR DESCRIPTION
Hier ist die Cassandra Config ersichtlich und wird nicht mehr im Hintergrund durch Spring übernommen.
Das wäre entsprechend auch die Stelle an der Startup oder Shutdown-Hooks eingebaut werden können.